### PR TITLE
Update Solution

### DIFF
--- a/Algorithms/Implementation/Extra Long Factorials/Solution.java
+++ b/Algorithms/Implementation/Extra Long Factorials/Solution.java
@@ -15,8 +15,7 @@ public class Solution {
         
         for(int i = 2; i <= N; i++)
         {
-            BigInteger multiplier = new BigInteger(String.valueOf(i));
-            factorial = factorial.multiply(multiplier);
+             factorial = factorial.multiply(BigInteger.valueOf(multiplier));
         }
         
         System.out.println(factorial);


### PR DESCRIPTION
Instead of using a variable for the conversion of int to BigInteger, we can directly convert it while multiplying. Thus it reduces one line of code and a variable.